### PR TITLE
Fix string escaping

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -740,11 +740,11 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 	for idx, msg := range sdktx.GetMsgs() {
 		f, _ := os.OpenFile(fmt.Sprintf("./extract/progress/messages.%d.%s", ctx.BlockHeight(), ctx.ChainID()), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 		msgString, _ := codec.Cdc.MarshalJSON(msg)
-		f.WriteString(fmt.Sprintf("%s,%d,%s,\"%s\",%s,%s\n",
+		f.WriteString(fmt.Sprintf("%s,%d,%s,$%s$,%s,%s\n",
 			txHash,
 			idx,
 			msg.Type(),
-			strings.ReplaceAll(string(msgString), "\"", "\"\""),
+			strings.ReplaceAll(string(msgString), "$", "\\$"),
 			ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"),
 			ctx.ChainID()))
 		f.Close()
@@ -752,17 +752,17 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 	}
 
 	f, _ := os.OpenFile(fmt.Sprintf("./extract/progress/txs.%d.%s", ctx.BlockHeight(), ctx.ChainID()), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-	f.WriteString(fmt.Sprintf("%s,%d,%d,%d,%d,\"%s\",%s,\"%s\",\"%s\",\"%s\",%s,%s\n",
+	f.WriteString(fmt.Sprintf("%s,%d,%d,%d,%d,$%s$,$%s$,$%s$,$%s$,$%s$,%s,%s\n",
 		txHash,
 		ctx.BlockHeight(),
 		uint32(result.Code),
 		int64(result.GasWanted),
 		int64(result.GasUsed),
-		strings.ReplaceAll(result.Log, "\"", "\"\""),
-		strings.ReplaceAll(string(jsonMemo), "\"", "\"\""),
-		strings.ReplaceAll(string(jsonFee), "\"", "\"\""),
-		strings.ReplaceAll(string(jsonTags), "\"", "\"\""),
-		strings.ReplaceAll(string(jsonMsgs), "\"", "\"\""),
+		strings.ReplaceAll(result.Log, "$", "\\$"),
+		strings.ReplaceAll(string(jsonMemo), "$", "\\$"),
+		strings.ReplaceAll(string(jsonFee), "$", "\\$"),
+		strings.ReplaceAll(string(jsonTags), "$", "\\$"),
+		strings.ReplaceAll(string(jsonMsgs), "$", "\\$"),
 		ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"),
 		ctx.ChainID()))
 	f.Close()


### PR DESCRIPTION
### Description
This PR changes the way we are writing data in csv. Instead of using `"` as quote we are using `$` and use escape character as `\`

### Logic
Since `"` is used in json plenty, we needed a different set of characters to act as quote and escape.

### Justification behind this change
PostgreSql's default quote and escape character both are `"`, which require us to produce ugly json via escaping `"` multiple times, and also creates a problem for string. 

Using `$` as quote enable us to put json as it is, and just escaping `$` character, which results in much cleaner output and also eliminate error with string like `""`.

### Companion PR:
https://github.com/ChorusOne/hipparchus/pull/17