### PR TITLE
SDK changes for a) handling non-bulky commissions data and b) zeroing out balances across all denominations

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -779,7 +779,9 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 	ctx := app.getContextForTx(runTxModeDeliver, req.Tx)
 
 	sdktx, _ := tx.(auth.StdTx)
+
 	jsonTags, _ := codec.Cdc.MarshalJSON(sdk.EventsToString(result.Events.ToABCIEvents()))
+	jsonEvents, _ := codec.Cdc.MarshalJSON(sdk.StringifyEvents(result.Events.ToABCIEvents()))
 	jsonMsgs := MsgsToString(sdktx.GetMsgs())
 	jsonFee, _ := codec.Cdc.MarshalJSON(sdktx.Fee)
 	jsonMemo, _ := codec.Cdc.MarshalJSON(sdktx.GetMemo())
@@ -799,7 +801,7 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 	}
 
 	f, _ := os.OpenFile(fmt.Sprintf("./extract/progress/txs.%d.%s", ctx.BlockHeight(), ctx.ChainID()), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-	f.WriteString(fmt.Sprintf("%s,%d,%d,%d,%d,$%s$,$%s$,$%s$,$%s$,$%s$,%s,%s\n",
+	f.WriteString(fmt.Sprintf("%s,%d,%d,%d,%d,$%s$,$%s$,$%s$,$%s$,$%s$,$%s$,%s,%s\n",
 		txHash,
 		ctx.BlockHeight(),
 		uint32(result.Code),
@@ -810,6 +812,7 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 		strings.ReplaceAll(string(jsonFee), "$", "\\$"),
 		strings.ReplaceAll(string(jsonTags), "$", "\\$"),
 		strings.ReplaceAll(string(jsonMsgs), "$", "\\$"),
+		strings.ReplaceAll(string(jsonEvents), "$", "\\$"),
 		ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"),
 		ctx.ChainID()))
 	f.Close()

--- a/baseapp/extractor_utils.go
+++ b/baseapp/extractor_utils.go
@@ -18,7 +18,7 @@ func copyFile(destination string, source string) error {
 	}
 	defer sourceFile.Close()
 
-	destinationFile, err := os.OpenFile(destination, os.O_WRONLY | os.O_CREATE | os.O_APPEND, 0644)
+	destinationFile, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		return fmt.Errorf("error: (%v) while trying to open destination file while copying", err)
 	}
@@ -33,7 +33,7 @@ func copyFile(destination string, source string) error {
 }
 
 func commitUncheckedFiles(ctx sdk.Context) {
-	for _, key := range []string{"delegations", "unbond", "balance", "rewards"} {
+	for _, key := range []string{"delegations", "unbond", "balance", "rewards", "commission"} {
 		err := copyFile(fmt.Sprintf("./extract/progress/%s.%d.%s", key, ctx.BlockHeight(), ctx.ChainID()), fmt.Sprintf("./extract/unchecked/%s.%d.%s", key, ctx.BlockHeight(), ctx.ChainID()))
 		if err != nil {
 			panic(fmt.Sprintf("error: (%v) while commiting unchecked file\n", err))
@@ -46,7 +46,7 @@ func commitUncheckedFiles(ctx sdk.Context) {
 }
 
 func deleteUncheckedFiles(ctx sdk.Context) {
-	for _, key := range []string{"delegations", "unbond", "balance", "rewards"} {
+	for _, key := range []string{"delegations", "unbond", "balance", "rewards", "commission"} {
 		if err := os.Remove(fmt.Sprintf("./extract/unchecked/%s.%d.%s", key, ctx.BlockHeight(), ctx.ChainID())); err != nil && !os.IsNotExist(err) {
 			panic(fmt.Sprintf("error: (%v) while removing unchecked file\n", err))
 		}

--- a/baseapp/extractor_utils.go
+++ b/baseapp/extractor_utils.go
@@ -7,6 +7,21 @@ import (
 	"os"
 )
 
+//Denominations represents the list of all denominations at a block height
+type Denominations = []string
+
+var genesisDenominations = map[string]Denominations{
+	//TODO : Find genesis denominations for all chains and update this list
+
+	"columbus-1": []string{"uatom"},
+	"columbus-2": []string{"uatom"},
+	"columbus-3": []string{"uatom"},
+
+	"cosmoshub-1": []string{"uatom"},
+	"cosmoshub-2": []string{"uatom"},
+	"cosmoshub-3": []string{"uatom"},
+}
+
 func copyFile(destination string, source string) error {
 	sourceFile, err := os.OpenFile(source, os.O_RDONLY, 0644)
 	if err != nil {

--- a/x/auth/keeper.go
+++ b/x/auth/keeper.go
@@ -114,7 +114,10 @@ func (ak AccountKeeper) SetAccount(ctx sdk.Context, acc exported.Account) {
 			var coins []sdk.Coin
 			coins = acc.GetCoins()
 			if coins == nil {
-				f.WriteString(fmt.Sprintf("%s,%s,%s,%d,%s,%s,%d, %d\n", acc.GetAddress(), "uatom", "0", ctx.BlockHeight(), ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"), ctx.ChainID(), acc.GetAccountNumber(), acc.GetSequence()))
+				for _, denomination := range ctx.Value("Denominations").([]string) {
+					f.WriteString(fmt.Sprintf("%s,%s,%s,%d,%s,%s,%d, %d\n", acc.GetAddress(), denomination, "0", ctx.BlockHeight(), ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"), ctx.ChainID(), acc.GetAccountNumber(), acc.GetSequence()))
+
+				}
 			} else {
 				for _, i := range coins {
 					f.WriteString(fmt.Sprintf("%s,%s,%s,%d,%s,%s,%d, %d\n", acc.GetAddress(), i.Denom, i.Amount.String(), ctx.BlockHeight(), ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"), ctx.ChainID(), acc.GetAccountNumber(), acc.GetSequence()))


### PR DESCRIPTION
Upgrading our cosmos-sdk fork on branch c1/0.37.7 from tag c1/0.37.7-1 to tag c1/0.37.7-2

The changes ensure that - similar to other file types (delegations, unbond, rewards etc) - the non-bulky commission files too progress from 'uncheck' folder to 'progress' folder on `commitUncheckedFiles()`

(or are deleted if all the other file types are deleted via `deleteUncheckedFiles()`. 

A corresponding PR will exist in the hipparchus repo to
- ensure hipparchus-0.37 points to the latest tag (tag c1/0.37.7-2) in go.mod +
- other changes to ensure non bulky commissions data is successfully pushed to the relevant Postgres table.

[TODO : Insert corresponding PR Link] 

Collectively, both these PR address [this issue](https://github.com/ChorusOne/hipparchus/issues/70) for Hipparchus-0.37 (need to follow up for Hipparchus-.34 and Hipparchus-0.33)




