### PR TITLE
Fix Multiple Issues for Hipparchus-0.37 

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -779,7 +779,9 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 	ctx := app.getContextForTx(runTxModeDeliver, req.Tx)
 
 	sdktx, _ := tx.(auth.StdTx)
+
 	jsonTags, _ := codec.Cdc.MarshalJSON(sdk.EventsToString(result.Events.ToABCIEvents()))
+	jsonEvents, _ := codec.Cdc.MarshalJSON(sdk.StringifyEvents(result.Events.ToABCIEvents()))
 	jsonMsgs := MsgsToString(sdktx.GetMsgs())
 	jsonFee, _ := codec.Cdc.MarshalJSON(sdktx.Fee)
 	jsonMemo, _ := codec.Cdc.MarshalJSON(sdktx.GetMemo())
@@ -799,7 +801,7 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 	}
 
 	f, _ := os.OpenFile(fmt.Sprintf("./extract/progress/txs.%d.%s", ctx.BlockHeight(), ctx.ChainID()), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-	f.WriteString(fmt.Sprintf("%s,%d,%d,%d,%d,$%s$,$%s$,$%s$,$%s$,$%s$,%s,%s\n",
+	f.WriteString(fmt.Sprintf("%s,%d,%d,%d,%d,$%s$,$%s$,$%s$,$%s$,$%s$,$%s$,%s,%s\n",
 		txHash,
 		ctx.BlockHeight(),
 		uint32(result.Code),
@@ -810,6 +812,7 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 		strings.ReplaceAll(string(jsonFee), "$", "\\$"),
 		strings.ReplaceAll(string(jsonTags), "$", "\\$"),
 		strings.ReplaceAll(string(jsonMsgs), "$", "\\$"),
+		strings.ReplaceAll(string(jsonEvents), "$", "\\$"),
 		ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"),
 		ctx.ChainID()))
 	f.Close()

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -339,11 +339,14 @@ func (app *BaseApp) setDeliverState(header abci.Header) {
 		//If Terra is tracking 10K+ denominations, we are looking at bigger scaling issues for Hipparchus!
 		//At that point, this should be a minor bug to fix.
 		queryTotalSupplyParams := QueryTotalSupplyParams{1, 10000}
-		//TODO : Handle Error
-		bz, _ := codec.Cdc.MarshalJSON(queryTotalSupplyParams)
-		//TODO Handle error
-		resBytes, _, _ := appQuerier.QueryWithData(queryPath, bz)
-
+		bz, err := codec.Cdc.MarshalJSON(queryTotalSupplyParams)
+		if err != nil {
+			panic(err)
+		}
+		resBytes, _, err2 := appQuerier.QueryWithData(queryPath, bz)
+		if err2 != nil {
+			panic(err2)
+		}
 		var allCoins sdk.Coins
 		codec.Cdc.UnmarshalJSON(resBytes, &allCoins)
 

--- a/baseapp/extractor_utils.go
+++ b/baseapp/extractor_utils.go
@@ -18,7 +18,7 @@ func copyFile(destination string, source string) error {
 	}
 	defer sourceFile.Close()
 
-	destinationFile, err := os.OpenFile(destination, os.O_WRONLY | os.O_CREATE | os.O_APPEND, 0644)
+	destinationFile, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		return fmt.Errorf("error: (%v) while trying to open destination file while copying", err)
 	}
@@ -33,7 +33,7 @@ func copyFile(destination string, source string) error {
 }
 
 func commitUncheckedFiles(ctx sdk.Context) {
-	for _, key := range []string{"delegations", "unbond", "balance", "rewards"} {
+	for _, key := range []string{"delegations", "unbond", "balance", "rewards", "commission"} {
 		err := copyFile(fmt.Sprintf("./extract/progress/%s.%d.%s", key, ctx.BlockHeight(), ctx.ChainID()), fmt.Sprintf("./extract/unchecked/%s.%d.%s", key, ctx.BlockHeight(), ctx.ChainID()))
 		if err != nil {
 			panic(fmt.Sprintf("error: (%v) while commiting unchecked file\n", err))
@@ -46,7 +46,7 @@ func commitUncheckedFiles(ctx sdk.Context) {
 }
 
 func deleteUncheckedFiles(ctx sdk.Context) {
-	for _, key := range []string{"delegations", "unbond", "balance", "rewards"} {
+	for _, key := range []string{"delegations", "unbond", "balance", "rewards", "commission"} {
 		if err := os.Remove(fmt.Sprintf("./extract/unchecked/%s.%d.%s", key, ctx.BlockHeight(), ctx.ChainID())); err != nil && !os.IsNotExist(err) {
 			panic(fmt.Sprintf("error: (%v) while removing unchecked file\n", err))
 		}

--- a/baseapp/extractor_utils.go
+++ b/baseapp/extractor_utils.go
@@ -7,6 +7,21 @@ import (
 	"os"
 )
 
+//Denominations represents the list of all denominations at a block height
+type Denominations = []string
+
+var genesisDenominations = map[string]Denominations{
+	//TODO : Find genesis denominations for all chains and update this list
+
+	"columbus-1": []string{"uatom"},
+	"columbus-2": []string{"uatom"},
+	"columbus-3": []string{"uatom"},
+
+	"cosmoshub-1": []string{"uatom"},
+	"cosmoshub-2": []string{"uatom"},
+	"cosmoshub-3": []string{"uatom"},
+}
+
 func copyFile(destination string, source string) error {
 	sourceFile, err := os.OpenFile(source, os.O_RDONLY, 0644)
 	if err != nil {

--- a/baseapp/extractor_utils.go
+++ b/baseapp/extractor_utils.go
@@ -11,11 +11,12 @@ import (
 type Denominations = []string
 
 var genesisDenominations = map[string]Denominations{
-	//TODO : Find genesis denominations for all chains and update this list
+	//TODO : Parse genesis denominations from genesis.json 
+	// https://github.com/ChorusOne/hipparchus/issues/78
 
-	"columbus-1": []string{"uatom"},
-	"columbus-2": []string{"uatom"},
-	"columbus-3": []string{"uatom"},
+	"columbus-1": []string{"ukrw", "uluna", "umnt", "usdr", "uusd"},
+	"columbus-2": []string{"ukrw", "uluna", "umnt", "usdr", "uusd"},
+	"columbus-3": []string{"ukrw", "uluna", "umnt", "usdr", "uusd"},
 
 	"cosmoshub-1": []string{"uatom"},
 	"cosmoshub-2": []string{"uatom"},

--- a/x/auth/keeper.go
+++ b/x/auth/keeper.go
@@ -114,7 +114,10 @@ func (ak AccountKeeper) SetAccount(ctx sdk.Context, acc exported.Account) {
 			var coins []sdk.Coin
 			coins = acc.GetCoins()
 			if coins == nil {
-				f.WriteString(fmt.Sprintf("%s,%s,%s,%d,%s,%s,%d, %d\n", acc.GetAddress(), "uatom", "0", ctx.BlockHeight(), ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"), ctx.ChainID(), acc.GetAccountNumber(), acc.GetSequence()))
+				for _, denomination := range ctx.Value("Denominations").([]string) {
+					f.WriteString(fmt.Sprintf("%s,%s,%s,%d,%s,%s,%d, %d\n", acc.GetAddress(), denomination, "0", ctx.BlockHeight(), ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"), ctx.ChainID(), acc.GetAccountNumber(), acc.GetSequence()))
+
+				}
 			} else {
 				for _, i := range coins {
 					f.WriteString(fmt.Sprintf("%s,%s,%s,%d,%s,%s,%d, %d\n", acc.GetAddress(), i.Denom, i.Amount.String(), ctx.BlockHeight(), ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"), ctx.ChainID(), acc.GetAccountNumber(), acc.GetSequence()))

--- a/x/auth/keeper.go
+++ b/x/auth/keeper.go
@@ -114,7 +114,17 @@ func (ak AccountKeeper) SetAccount(ctx sdk.Context, acc exported.Account) {
 			var coins []sdk.Coin
 			coins = acc.GetCoins()
 			if coins == nil {
-				for _, denomination := range ctx.Value("Denominations").([]string) {
+
+				if ctx.Value("Denominations") == nil {
+					panic("Unable to record balances for an empty wallet, as list of denomination is missing")
+				}
+
+				denominations, ok := ctx.Value("Denominations").([]string)
+
+				if !ok {
+					panic("Unable to record balances for an empty wallet, as list of denominations passed is not of type []string")
+				}
+				for _, denomination := range denominations {
 					f.WriteString(fmt.Sprintf("%s,%s,%s,%d,%s,%s,%d, %d\n", acc.GetAddress(), denomination, "0", ctx.BlockHeight(), ctx.BlockHeader().Time.Format("2006-01-02 15:04:05"), ctx.ChainID(), acc.GetAccountNumber(), acc.GetSequence()))
 
 				}


### PR DESCRIPTION
This pull request consists of changes to `ChorusOne/cosmos-sdk v0.37.7-1` to address the following issues for `hipparchus-0.37` - 

1. [Zero out balances for accounts that moved all funds out for all denoms ](https://github.com/ChorusOne/hipparchus/issues/71)
   - cosmos-sdk will now dump zero balances across all denominations (and not just uatom) for when an account is emptied.
   - [x] TODO : Find out genesis denominations for all chains - as these need to be hardcoded 

2. [Cosmos Hub 3 Transaction tags](https://github.com/ChorusOne/hipparchus/issues/66)
   - All transaction rows in tx.* files now contain an extra column called `events` holding the Events JSON object for the tx.
   - Additionally, `submitters/transactions.sh` have been updated in  the`hipparchus` repo to handle the extra column in transaction dumps.

   - [ ] TODO : This breaks backward compatibility of `submitters` for `hipparchus-0.33` and `hipparchus-0.37`. Address this when you resolve these issues for these versions. 

3. [Rewards data for days in which a withdrawal took place understate reward](https://github.com/ChorusOne/hipparchus/issues/70)
   - The changes ensure that - similar to other file types (delegations, unbond, rewards etc) - the non-bulky commission files  also 
a) progress from 'uncheck' folder to 'progress' folder when commitUncheckedFiles() is invoked
b) and are deleted when deleteUncheckedFiles() is invoked

--- 

With the above changes, I have bumped up `ChorusOne/cosmos-sdk v0.37.7-1` to [`v0.37.7-2`](https://github.com/ChorusOne/cosmos-sdk/releases/tag/v0.37.7-2)

--- 

A corresponding pull request exists in `ChorusOne/hipparchus` (Insert Link when ready) - which along with other changes - now 'requires' `v0.37.7-2` in the `go.mod` of `hipparchus-0.37`. 

Collectively, these two pull requests take a shot at resolving the 3 issues. 

--- 

Post Joe's review and Ankit's follow up commits
- [x] Point v0.37.7-2 to the final `HEAD` of this branch. 

- [ ] Resolve these issues in Hipparchus-0.33 and Hipparchus-0.34 






